### PR TITLE
Source Apollokino

### DIFF
--- a/src/boringhannover/sources/cinema/apollokino.py
+++ b/src/boringhannover/sources/cinema/apollokino.py
@@ -1,0 +1,182 @@
+"""Scraper for Apollokino Hannover-Linden.
+
+Parses Apollokino HTML pages. The pages use repeated sections 
+with a `div.datumzeile` followed by `table.filmtabelle`. 
+Each film entry is represented inside a `table.tagestabelle`.
+
+Apollokino has a separate page for OV shows (OmU-Nachtstudio)
+that we focus on for now:
+https://www.apollokino.de/?mp=OmU-Nachtstudio
+
+Main page for the weekly schedule, including dubbed versions:
+https://www.apollokino.de/?v=&mp=Diese%20Woche
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+from typing import ClassVar
+from urllib.parse import urljoin
+
+from bs4 import BeautifulSoup
+
+from boringhannover.models import Event
+from boringhannover.sources.base import (
+    BaseSource,
+    create_http_client,
+    parse_german_date,
+    is_original_version,
+    register_source,
+)
+
+
+__all__ = ["ApollokinoSource"]
+
+logger = logging.getLogger(__name__)
+
+
+@register_source("apollokino")
+class ApollokinoSource(BaseSource):
+    """Scraper for the Apollokino Hannover-Linden."""
+
+    source_name: ClassVar[str] = "Apollokino Hannover"
+    source_type: ClassVar[str] = "cinema"
+
+    # Use the OmU-specific page
+    PAGE_URL: ClassVar[str] = "https://www.apollokino.de/?mp=OmU-Nachtstudio"
+
+    TIME_TITLE_RE = re.compile(r"^(?P<time>\d{1,2}:\d{2}):?\s*(?P<title>.+)$")
+    # Exclude known non-film shows
+    BLACKLIST = ("desimo", "spezial club")
+
+    def fetch(self) -> list[Event]:
+        logger.info("Fetching Apollokino page: %s", self.PAGE_URL)
+        with create_http_client() as client:
+            resp = client.get(self.PAGE_URL)
+            resp.raise_for_status()
+            soup = BeautifulSoup(resp.text, "html.parser")
+
+        events: list[Event] = []
+
+        # Iterate over date blocks: a date line followed by a filmtabelle
+        date_lines = soup.find_all("div", class_="datumzeile")
+        for date_line in date_lines:
+            date_text = date_line.get_text(separator=" ", strip=True)
+            base_date = parse_german_date(date_text)
+            if base_date is None:
+                logger.debug("Could not parse date from: %s", date_text)
+                continue
+
+            # Next sibling(s) may include whitespace/text nodes; find next table.filmtabelle
+            table = None
+            nxt = date_line.next_sibling
+            while nxt is not None:
+                # BeautifulSoup may return strings; ensure Tag
+                if getattr(nxt, "name", None) == "table" and "filmtabelle" in (nxt.get("class") or []):
+                    table = nxt
+                    break
+                nxt = nxt.next_sibling
+
+            if table is None:
+                # Try a fallback: searchNearby
+                table = date_line.find_next("table", class_="filmtabelle")
+            if table is None:
+                continue
+
+            # Inside filmtabelle -> find inner tagestabelle and film rows
+            for tagestabelle in table.find_all("table", class_="tagestabelle"):
+                for tr in tagestabelle.find_all("tr"):
+                    td = tr.find("td")
+                    if not td:
+                        continue
+
+                    # Title & time
+                    a = td.find("a")
+                    title_text = ""
+                    detail_href = ""
+                    if a:
+                        title_el = a.find("h2", class_="filmtitel")
+                        title_text = title_el.get_text(separator=" ", strip=True) if title_el else a.get_text(separator=" ", strip=True)
+                        detail_href = a.get("href") or ""
+                    else:
+                        title_h2 = td.find("h2", class_="filmtitel")
+                        if title_h2:
+                            title_text = title_h2.get_text(separator=" ", strip=True)
+
+                    m = self.TIME_TITLE_RE.match(title_text)
+                    if not m:
+                        logger.debug("Skipping row, cannot parse time/title: %r", title_text)
+                        continue
+
+                    time_str = m.group("time")
+                    film_title = m.group("title").strip()
+                    film_title_lower = film_title.lower()
+
+                    # Combine base_date with time
+                    try:
+                        hour, minute = map(int, time_str.split(":"))
+                        dt = base_date.replace(hour=hour, minute=minute, second=0)
+                    except Exception:
+                        logger.debug("Invalid time %r for title %r", time_str, film_title)
+                        continue
+
+                    # Synopsis
+                    synopsis_el = td.find("div", class_="filminhalt")
+                    synopsis = synopsis_el.get_text(separator=" ", strip=True) if synopsis_el else ""
+
+                    # Series / language note
+                    note_el = td.find("div", class_="filmanmerkung")
+                    note = note_el.get_text(separator=" ", strip=True) if note_el else ""
+                    note_lower = note.lower() if note else ""
+
+                    # Poster
+                    img = td.find("img")
+                    poster_url = urljoin(self.PAGE_URL, img["src"]) if img and img.get("src") else ""
+
+                    # Ticket URL from form action
+                    form = td.find("form")
+                    ticket_url = form.get("action") if form and form.get("action") else ""
+                    if ticket_url:
+                        ticket_url = urljoin(self.PAGE_URL, ticket_url)
+
+                    # Detail page
+                    detail_url = urljoin(self.PAGE_URL, detail_href) if detail_href else ""
+
+                    # Filter for OmU (site marks OmU shows in filmanmerkung)
+                    if "omu-nachtstudio" not in note_lower:
+                        logger.debug(
+                            "Skipping non-OmU (filmanmerkung missing): %s (%s)",
+                            film_title,
+                            note,
+                        )
+                        continue
+
+                    # Exclude known non-film shows like DESiMO
+                    if any(b in note_lower for b in self.BLACKLIST) or any(b in film_title_lower for b in self.BLACKLIST):
+                        logger.debug("Skipping blacklisted show: %s (%s)", film_title, note)
+                        continue
+
+                    # Choose event URL: prefer detail page, then ticket action, then page URL
+                    event_url = detail_url or ticket_url or self.PAGE_URL
+
+                    try:
+                        ev = Event(
+                            title=film_title,
+                            date=dt,
+                            venue=self.source_name,
+                            url=event_url,
+                            category="movie",
+                            metadata={
+                                "synopsis": synopsis,
+                                "original_version": True,
+                                "poster_url": poster_url,
+                            },
+                        )
+                        events.append(ev)
+                    except Exception as exc:
+                        logger.debug("Skipping event due to validation error: %s", exc)
+
+        logger.info("Apollokino: parsed %d events", len(events))
+        return events

--- a/tests/fixtures/apollokino_detail.html
+++ b/tests/fixtures/apollokino_detail.html
@@ -1,0 +1,148 @@
+<!-- 2025-12-31 copy of https://www.apollokino.de/?v=&film=filme/01000749&anmerk=OmU-Nachtstudio -->
+<!DOCTYPE html><head><title> Apollokino Hannover-Linden </title>
+<meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate" />
+<meta http-equiv="pragma" content="no-cache" />
+<meta http-equiv="expires" content="0" />
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+<meta name="Keywords" content="Kino, Hannver, Linden, Programm, Film, Filme, Filmkunst, Niedersachsen, Programmkino" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="dns-prefetch" href="http://m.apollokino.de" />
+<link rel="alternate" media="only screen and (max-width: 640px)" href="//m.apollokino.de/" id="mobil_variante" />
+<link rel="shortcut icon" href="/favicon.ico" />
+<link rel="stylesheet" type="text/css" href="/default.css" />
+<link href="/themes/1/js-image-slider.css" rel="stylesheet" type="text/css" />
+<script src="/themes/1/js-image-slider.js" type="text/javascript"></script>
+<script type="text/javascript" language="JavaScript">
+// Erkennung Bildschirmgroesse 
+if (screen.availWidth < 640) {
+   window.location.href = "http://m.apollokino.de/";
+
+}
+function toggle (id1) {
+   var obj1 = document.getElementById(id1);
+   (obj1.className=="itemshown") ? obj1.className="itemhidden" : obj1.className="itemshown"; 
+}
+function GoVorschau(x) {
+   location.href = "/?inhalt=menue/apollo/00000003&suche=" + x;
+}
+var image1=new Image()
+image1.src="/images/apolloshow3.jpg"
+var image2=new Image()
+image2.src="/images/apolloshow2.jpg"
+var image3=new Image()
+image3.src="/images/apolloshow1.jpg"
+var image4=new Image()
+image4.src="/images/apolloshow4.jpg"
+var image5=new Image()
+image5.src="/images/apolloshow5.jpg"
+var image6=new Image()
+image6.src="/images/apolloshow6.jpg"
+var image7=new Image()
+image7.src="/images/apolloshow7.jpg"
+                    
+var number_of_images=7					// Anzahl der Grafiken
+var speed=5						// Geschwindigkeit des FilterÃ¼bergang
+var step=1						// Schrittanzahl
+var image=1						// Start der ersten Grafik
+function slideit() {
+   if (!document.images)
+      return
+   if (document.all)
+      slide.filters.blendTrans.apply()
+   document.images.slide.src=eval("image"+step+".src")
+   if (document.all)
+      slide.filters.blendTrans.play()
+   whichimage=step
+   if (step<number_of_images)
+      step++
+   else
+      step=1
+   if (document.all)
+      setTimeout("slideit()",speed*1000+2500)
+   else
+      setTimeout("slideit()",speed*1000)
+}
+function slidelink() {
+   if (whichimage==1)
+      window.location="#"
+   else if (whichimage==2)
+      window.location="#"
+   else if (whichimage==3)
+      window.location="#"
+   else if (whichimage==4)
+      window.location="#"
+   else if (whichimage==5)
+      window.location="#"
+}
+
+</script>
+</head><body onload="slideit();"><div id="header">
+<table><tr><td width=300 align=left><a href="/" target=_top><img src="/images/apollokino-300.png" width=300 title="Apollokino Hannover-Linden" border=0></a>
+</td><td width=100% align=right><img src="/images/apolloshow3.jpg" width=600 height=100 name="slide" border=0 style="filter:blendTrans(duration=3)"></td></tr></table>
+</div>
+<div id=menue><span class=menuborder><a class=menu href="/?v=&mp=Aktuell">Aktuell</a></span>
+<span class=menuborder><a class=menu href="/?v=&mp=Diese Woche">Diese Woche</a></span>
+<span class=menuborder><a class=menu href="/?v=&mp=Vorschau">Vorschau</a></span>
+<span class=menuborder><a class=menu href="/?v=&mp=Tickets">Tickets</a></span>
+<span class=menuborder><a class=menu href="/?v=&mp=Anfahrt">Anfahrt</a></span>
+<span class=menuborder><a class=menu href="/?v=&mp=Newsletter">Newsletter</a></span>
+<span class=menuborder><a class=menu href="http://www.filmkunstkinos-hannover.de" target=_blank>Raschplatz & Hochhaus</a></span>
+<span class=menuborder><a class=menu href="http://m.apollokino.de/" target=_blank>Mobil</a></span>
+</div><div id=content><div id=links><div class=linksborder><a class=links href="https://www.spezialclub.de/" title="SIE WERDEN LACHEN! 
+Die Bühne für Comedy, Kabarett, Mix-Shows, 
+Gastspiele und Kleinkunst in Hannover zusammengestellt und empfohlen von DESIMO " target=_blank><img src="/links/apollo/00000001/logo.jpg" border=0 width=200 alt="Desimos Special Club" title="SIE WERDEN LACHEN! 
+Die Bühne für Comedy, Kabarett, Mix-Shows, 
+Gastspiele und Kleinkunst in Hannover zusammengestellt und empfohlen von DESIMO "></a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Kino zu mieten">Kino zu mieten</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Schulkino">Schulvorstellungen</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Kurzfilme">Kurzfilme</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Vino-Kino">Vino-Kino</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=OmU-Nachtstudio">OmU-Nachtstudio</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Kinderwagen">Kinderwagen-Kino</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Cinema Craft Club">Cinema Craft Club</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Sondervorstellungen">Sondervorstellungen</a>
+</div><div class=linksborder><a class=links href="http://www.mongay.de" title="An jedem zweiten Montag im Monat um 20.15 Uhr gibt es schwules Kino in Zusammenarbeit mit der Gay-Filmnacht. 
+" target=_blank>MonGay</a>
+</div><div class=linksborder><a class=links href="http://www.womongay.de" title="An jedem dritten Montag im Monat um 20.15 Uhr gibt es lesbisches Kino in Zusammenarbeit mit der L-Filmnacht. " target=_blank>WoMonGay</a>
+</div><div class=linksborder><a class=links href="http://www.filmtipps-hannover.de/filmtipps_Hannover/Home.html" title="FILMTIPPS ist die Programmzeitung der Filmkunstkinos-Hannover mit den Monatsprogrammen der hannoverschen Programmkinos. Dort finden Sie auch das APOLLO-Programm für den ganzen Monat als pdf zum runterladen: 
+" target=_blank>Filmtipps</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Apollokino">Das Kino</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Geschichte">Geschichte</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Impressum">Impressum</a>
+</div><span class=filminhalt> <br>
+Limmerstraße 50<br>
+30451 Hannover<br>
+Telefon/Fax: 0511 / 452438<br>
+(täglich ab 17:30 Uhr)<br>
+<a href=mailto:info@apollokino.de>info@apollokino.de</a><br>
+<br>
+Kinokarten können nur telefonisch täglich ab 17:30 Uhr vorbestellt werden!<br>
+<br>
+Kassenöffnung: 30 Minuten vor Beginn der ersten Vorstellung.<br>
+<br>
+<a href="https://www.instagram.com/apollokinohannover/?hl=de" target=_blank><img src="/images/icon-instagram.png" width=32 hspace=5 title="Apollokino bei Instagram" border=0></a> <a href="https://www.facebook.com/Apollo-Kino-302530716440092" target=_blank><img src="/images/icon-facebook.png" width=32 hspace=5 title="Apollokino bei Facebook" border=0></a><br>
+<br>
+Wir sind Mitglied<br>
+<a href="http://www.europa-cinemas.org" target=_blank><img src=/images/ec-200.jpg width=200 title="Europa Cinemas" border=0></a><br>
+<br>
+Wir sind Mitglied<br>
+<a href="http://www.agkino.de" target=_blank><img src=/images/agkino-gilde-300.jpg width=200 title="Arbeitsgemeinschaft Kino" border=0></a><br>
+<br>
+Gefördert mit Mitteln der EU<br>
+<img src=/images/eu.jpg width=200 title="EU" border=0><br>
+<br>
+Gefördert mit Mitteln der nordmedia<br>
+<a href="http://www.nordmedia.de" target=_blank><img src=/images/nordmedia.jpg width=200 title="Nordmedia" border=0></a><br>
+</span><div class=linksborder><a class=links href="/?v=&mp=Datenschutz">Datenschutzerklärung</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Barrierfreiheit">Barrierefreiheitserklärung</a>
+</div></div><div id="inhalt"><table><tr><td><h2 class=filmtitel>Der weisse Hai</h2><img src="/filme/01000749/plakat01000749.jpg" class=filmplakat alt="Filmplakat Der weisse Hai" title="Der weisse Hai">
+<div class=filmanmerkung>OmU-Nachtstudio</div><div class=filmdaten>
+USA 1975, 124 Min., ab 16 J., R: Steven Spielberg, mit: Roy Scheider, Robert Shaw, Richard Dreyfuss, Lorraine Gary, Murray Hamilton u.a.</div><div class=filminhalt>
+Steven Spiebergs Hai-Blockbuster  von 1975 mit Roy Scheider, Robert Shaw, Richard Dreyfuss, Lorraine Gary ist der Meilenstein des Kinos der 70er Jahre!<br>
+Spielberg vermischt Humor und Wohlbekanntes mit Horror und ungeahnten Schrecken.<br>
+An den Stränden eines kleinen Badeortes an der amerikanischen Ostküste taucht mitten in der Hauptsaison ein riesiger weißer Hai auf und verbreitet Angst und Schrecken. Polizeichef Martin Brody drängt auf eine Schließung der Strände, um Schlimmeres zu verhindern. Doch die Stadtverwaltung möchte Gerüchte über einen menschenfressenden Hai im Keim ersticken; das würde die Touristen abschrecken. Nach ersten Todesopfern machen sich drei Männer auf die abenteuerliche Jagd nach dem riesigen Meeresungeheuer, das sich als äußerst heimtückischer Gegner erweist.<br>
+<br>
+"Der Film erweist sich trotz der überbetonten Schockeffekte vor allem im zweiten Teil als ein atmosphärisch dichter, vorzüglich gespielter Abenteuerfilm im Gefolge Herman Melvilles."<br>
+Lexikon des internationalen Films</div><div class=filmhomepage><a href="https://www.youtube.com/watch?v=bBBBbadAkwM" target=_blank> Weitere Infos finden Sie hier.</a></div><div class=filmweitere>Spieltermine<br><form action=https://kinotickets.express/apollo_hannover/booking/12966
+ target=tickets><input type=submit value="02.01.2026 - 22:30"></form><form action=https://kinotickets.express/apollo_hannover/booking/13110
+ target=tickets><input type=submit value="14.02.2026 - 22:30"></form></td></tr></table></div></div></body></html>

--- a/tests/fixtures/apollokino_omu.html
+++ b/tests/fixtures/apollokino_omu.html
@@ -1,0 +1,515 @@
+<!-- 2025-12-31 copy of https://www.apollokino.de/?v=&mp=OmU-Nachtstudio -->
+<!DOCTYPE html><head><title> Apollokino Hannover-Linden </title>
+<meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate" />
+<meta http-equiv="pragma" content="no-cache" />
+<meta http-equiv="expires" content="0" />
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+<meta name="Keywords" content="Kino, Hannver, Linden, Programm, Film, Filme, Filmkunst, Niedersachsen, Programmkino" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="dns-prefetch" href="http://m.apollokino.de" />
+<link rel="alternate" media="only screen and (max-width: 640px)" href="//m.apollokino.de/" id="mobil_variante" />
+<link rel="shortcut icon" href="/favicon.ico" />
+<link rel="stylesheet" type="text/css" href="/default.css" />
+<link href="/themes/1/js-image-slider.css" rel="stylesheet" type="text/css" />
+<script src="/themes/1/js-image-slider.js" type="text/javascript"></script>
+<script type="text/javascript" language="JavaScript">
+// Erkennung Bildschirmgroesse 
+if (screen.availWidth < 640) {
+   window.location.href = "http://m.apollokino.de/";
+
+}
+function toggle (id1) {
+   var obj1 = document.getElementById(id1);
+   (obj1.className=="itemshown") ? obj1.className="itemhidden" : obj1.className="itemshown"; 
+}
+function GoVorschau(x) {
+   location.href = "/?inhalt=menue/apollo/00000003&suche=" + x;
+}
+var image1=new Image()
+image1.src="/images/apolloshow3.jpg"
+var image2=new Image()
+image2.src="/images/apolloshow2.jpg"
+var image3=new Image()
+image3.src="/images/apolloshow1.jpg"
+var image4=new Image()
+image4.src="/images/apolloshow4.jpg"
+var image5=new Image()
+image5.src="/images/apolloshow5.jpg"
+var image6=new Image()
+image6.src="/images/apolloshow6.jpg"
+var image7=new Image()
+image7.src="/images/apolloshow7.jpg"
+                    
+var number_of_images=7					// Anzahl der Grafiken
+var speed=5						// Geschwindigkeit des FilterÃ¼bergang
+var step=1						// Schrittanzahl
+var image=1						// Start der ersten Grafik
+function slideit() {
+   if (!document.images)
+      return
+   if (document.all)
+      slide.filters.blendTrans.apply()
+   document.images.slide.src=eval("image"+step+".src")
+   if (document.all)
+      slide.filters.blendTrans.play()
+   whichimage=step
+   if (step<number_of_images)
+      step++
+   else
+      step=1
+   if (document.all)
+      setTimeout("slideit()",speed*1000+2500)
+   else
+      setTimeout("slideit()",speed*1000)
+}
+function slidelink() {
+   if (whichimage==1)
+      window.location="#"
+   else if (whichimage==2)
+      window.location="#"
+   else if (whichimage==3)
+      window.location="#"
+   else if (whichimage==4)
+      window.location="#"
+   else if (whichimage==5)
+      window.location="#"
+}
+
+</script>
+</head><body onload="slideit();"><div id="header">
+<table><tr><td width=300 align=left><a href="/" target=_top><img src="/images/apollokino-300.png" width=300 title="Apollokino Hannover-Linden" border=0></a>
+</td><td width=100% align=right><img src="/images/apolloshow3.jpg" width=600 height=100 name="slide" border=0 style="filter:blendTrans(duration=3)"></td></tr></table>
+</div>
+<div id=menue><span class=menuborder><a class=menu href="/?v=&mp=Aktuell">Aktuell</a></span>
+<span class=menuborder><a class=menu href="/?v=&mp=Diese Woche">Diese Woche</a></span>
+<span class=menuborder><a class=menu href="/?v=&mp=Vorschau">Vorschau</a></span>
+<span class=menuborder><a class=menu href="/?v=&mp=Tickets">Tickets</a></span>
+<span class=menuborder><a class=menu href="/?v=&mp=Anfahrt">Anfahrt</a></span>
+<span class=menuborder><a class=menu href="/?v=&mp=Newsletter">Newsletter</a></span>
+<span class=menuborder><a class=menu href="http://www.filmkunstkinos-hannover.de" target=_blank>Raschplatz & Hochhaus</a></span>
+<span class=menuborder><a class=menu href="http://m.apollokino.de/" target=_blank>Mobil</a></span>
+</div><div id=content><div id=links><div class=linksborder><a class=links href="https://www.spezialclub.de/" title="SIE WERDEN LACHEN! 
+Die Bühne für Comedy, Kabarett, Mix-Shows, 
+Gastspiele und Kleinkunst in Hannover zusammengestellt und empfohlen von DESIMO " target=_blank><img src="/links/apollo/00000001/logo.jpg" border=0 width=200 alt="Desimos Special Club" title="SIE WERDEN LACHEN! 
+Die Bühne für Comedy, Kabarett, Mix-Shows, 
+Gastspiele und Kleinkunst in Hannover zusammengestellt und empfohlen von DESIMO "></a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Kino zu mieten">Kino zu mieten</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Schulkino">Schulvorstellungen</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Kurzfilme">Kurzfilme</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Vino-Kino">Vino-Kino</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=OmU-Nachtstudio">OmU-Nachtstudio</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Kinderwagen">Kinderwagen-Kino</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Cinema Craft Club">Cinema Craft Club</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Sondervorstellungen">Sondervorstellungen</a>
+</div><div class=linksborder><a class=links href="http://www.mongay.de" title="An jedem zweiten Montag im Monat um 20.15 Uhr gibt es schwules Kino in Zusammenarbeit mit der Gay-Filmnacht. 
+" target=_blank>MonGay</a>
+</div><div class=linksborder><a class=links href="http://www.womongay.de" title="An jedem dritten Montag im Monat um 20.15 Uhr gibt es lesbisches Kino in Zusammenarbeit mit der L-Filmnacht. " target=_blank>WoMonGay</a>
+</div><div class=linksborder><a class=links href="http://www.filmtipps-hannover.de/filmtipps_Hannover/Home.html" title="FILMTIPPS ist die Programmzeitung der Filmkunstkinos-Hannover mit den Monatsprogrammen der hannoverschen Programmkinos. Dort finden Sie auch das APOLLO-Programm für den ganzen Monat als pdf zum runterladen: 
+" target=_blank>Filmtipps</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Apollokino">Das Kino</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Geschichte">Geschichte</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Impressum">Impressum</a>
+</div><span class=filminhalt> <br>
+Limmerstraße 50<br>
+30451 Hannover<br>
+Telefon/Fax: 0511 / 452438<br>
+(täglich ab 17:30 Uhr)<br>
+<a href=mailto:info@apollokino.de>info@apollokino.de</a><br>
+<br>
+Kinokarten können nur telefonisch täglich ab 17:30 Uhr vorbestellt werden!<br>
+<br>
+Kassenöffnung: 30 Minuten vor Beginn der ersten Vorstellung.<br>
+<br>
+<a href="https://www.instagram.com/apollokinohannover/?hl=de" target=_blank><img src="/images/icon-instagram.png" width=32 hspace=5 title="Apollokino bei Instagram" border=0></a> <a href="https://www.facebook.com/Apollo-Kino-302530716440092" target=_blank><img src="/images/icon-facebook.png" width=32 hspace=5 title="Apollokino bei Facebook" border=0></a><br>
+<br>
+Wir sind Mitglied<br>
+<a href="http://www.europa-cinemas.org" target=_blank><img src=/images/ec-200.jpg width=200 title="Europa Cinemas" border=0></a><br>
+<br>
+Wir sind Mitglied<br>
+<a href="http://www.agkino.de" target=_blank><img src=/images/agkino-gilde-300.jpg width=200 title="Arbeitsgemeinschaft Kino" border=0></a><br>
+<br>
+Gefördert mit Mitteln der EU<br>
+<img src=/images/eu.jpg width=200 title="EU" border=0><br>
+<br>
+Gefördert mit Mitteln der nordmedia<br>
+<a href="http://www.nordmedia.de" target=_blank><img src=/images/nordmedia.jpg width=200 title="Nordmedia" border=0></a><br>
+</span><div class=linksborder><a class=links href="/?v=&mp=Datenschutz">Datenschutzerklärung</a>
+</div><div class=linksborder><a class=links href="/?v=&mp=Barrierfreiheit">Barrierefreiheitserklärung</a>
+</div></div><div id="inhalt"><h2>OmU-Nachtstudio</h2>Im Nachtstudio im APOLLO - Studio für Filmkunst zeigen wir internationale Filme in der jeweiligen Landessprache mit deutschen Untertiteln zum vergünstigsten Eintritt für alle von nur 7,- € !<br><div class=datumzeile>Dienstag, 30.12.2025</div><table class=filmtabelle><tr><td class=datumspalte>Dienstag<h1>30</h1>Dezember</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005138&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: THE MASTERMIND</h2>
+<img src="/filme/00005138/plakat00005138.jpg" border=0 width=100 align=right alt="Filmplakat THE MASTERMIND" title="THE MASTERMIND">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Nach der Premiere in Cannes kommt jetzt der gelungene Krimi zu uns ins Kino! 
+Die packende Geschichte eines rebellierenden Handwerkers, der im Amerika der 70er Jahre aus seinem Alltag auszubrechen versucht. 
+In einer beschaulichen Ecke von Massachusetts um 1970 versucht sich der arbeitslose Tischler 
+JB Mooney (Josh O?Connor) als Amateur-Kunstdieb und plant seinen ersten großen Coup. Doch 
+der Pla...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/12922
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Freitag, 02.01.2026</div><table class=filmtabelle><tr><td class=datumspalte>Freitag<h1>02</h1>Januar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/01000749&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: Der weisse Hai</h2>
+<img src="/filme/01000749/plakat01000749.jpg" border=0 width=100 align=right alt="Filmplakat Der weisse Hai" title="Der weisse Hai">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Steven Spiebergs Hai-Blockbuster  von 1975 mit Roy Scheider, Robert Shaw, Richard Dreyfuss, Lorraine Gary ist der Meilenstein des Kinos der 70er Jahre! 
+Spielberg vermischt Humor und Wohlbekanntes mit Horror und ungeahnten Schrecken. 
+An den Stränden eines kleinen Badeortes an der amerikanischen Ostküste taucht mitten in der Hauptsaison ein riesiger weißer Hai auf und verbreitet Angst und Schrecke...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/12966
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Samstag, 03.01.2026</div><table class=filmtabelle><tr><td class=datumspalte>Samstag<h1>03</h1>Januar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00001083&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: HAROLD AND MAUDE</h2>
+<img src="/filme/00001083/plakat00001083.jpg" border=0 width=100 align=right alt="Filmplakat HAROLD AND MAUDE" title="HAROLD AND MAUDE">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>
+ Hal Ashbys anarchistische Kultkomödie erzählt die Liebesgeschichte zwischen einem 18- und einer 79-Jährigen mit der Musik von Cat Stevens. Harold ist depressiv und kauzig. Die Aufmerksamkeit seiner begüterten Familie versucht er durch spektakuläre Selbstmordinszenierungen zu erringen. Er lernt die 79jährige Maude kennen, deren Exzentrik ihn fasziniert. Er verliebt sich in sie und will sie heirat...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/12967
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Donnerstag, 08.01.2026</div><table class=filmtabelle><tr><td class=datumspalte>Donnerstag<h1>08</h1>Januar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005165&anmerk=%20OmU-Nachtstudio"><h2 class=filmtitel>22:45: BUGONIA</h2>
+<img src="/filme/00005165/plakat00005165.jpg" border=0 width=100 align=right alt="Filmplakat BUGONIA" title="BUGONIA">
+</a>
+<div class=filmanmerkung> OmU-Nachtstudio</div>
+<div class=filminhalt>3 GOLDEN GLOBE-Nominierungen, u.a. Bester Film, Emma Stone! 
+Der neue Film von Regiemeister GIORGOS LANTHIMOS (POOR THINGS, THE FAVORITTE, THE LOBSTER) wieder mit EMMA STONE (POOR THINGS, LA LA LAND).  
+Zwei Freunde mit einer starken Neigung zu Verschwörungstheorien fassen einen riskanten Plan: Sie entführen die mächtige Geschäftsführerin eines bedeutenden Unternehmens. Angetrieben von ihrer Überz...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13021
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Samstag, 10.01.2026</div><table class=filmtabelle><tr><td class=datumspalte>Samstag<h1>10</h1>Januar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005151&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:45: Der Hochstapler</h2>
+<img src="/filme/00005151/plakat00005151.jpg" border=0 width=100 align=right alt="Filmplakat Der Hochstapler" title="Der Hochstapler">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Kriminalfilm von Derek Cianfrance (Blue Valentine, The Place Beyond the Pines) nach der wahren Geschichte des exzentrischen Serienräuber Jeffrey Manchester, der mehr als 60 Fillialen einer Fast-Food-Kette ausraubte. 
+Der ehemalige Army Ranger beginnt, Löcher in die ihre von Mc Donalds-Restaurants zu schneiden, wodurch er den Spitznamen ROOFMAN erhält. 
+Nachdem er aus dem Gefängnis entkommt, lebt e...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13022
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Donnerstag, 15.01.2026</div><table class=filmtabelle><tr><td class=datumspalte>Donnerstag<h1>15</h1>Januar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005174&anmerk=%20OmU-Nachtstudio"><h2 class=filmtitel>22:30: SENTIMENTAL VALUE </h2>
+<img src="/filme/00005174/SentimentalValueplDtNeu.jpg" border=0 width=100 align=right alt="Filmplakat SENTIMENTAL VALUE " title="SENTIMENTAL VALUE ">
+</a>
+<div class=filmanmerkung> OmU-Nachtstudio</div>
+<div class=filminhalt>8 GOLDEN GLOBE-Nominierungen, u.a. Bester Film, Beste Regie, Beste Hauptdarstellerin! 
+Nominiert für 5 Europäische Filmpreise (u.a. Bester Film, Beste Regie, Beste darstellerin, Bester Darsteller). Norw. OSCAR-Beitrag! Publikumspreis Filmfest München! 
+Ein neuer sensibler Film voller Emotionen von JOACHIM TRIER (DER schlimmste Mensch der Welt), wieder mit RENATE REINSVE, die mit dem Großen Preis d...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13019
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Freitag, 16.01.2026</div><table class=filmtabelle><tr><td class=datumspalte>Freitag<h1>16</h1>Januar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005019&anmerk=%20OmU-Nachtstudio"><h2 class=filmtitel>22:45: THE LIFE OF CHUCK</h2>
+<img src="/filme/00005019/plakat00005019.jpg" border=0 width=100 align=right alt="Filmplakat THE LIFE OF CHUCK" title="THE LIFE OF CHUCK">
+</a>
+<div class=filmanmerkung> OmU-Nachtstudio</div>
+<div class=filminhalt>Publikumspreis beim Toronto International Film Festival! 
+Die außergewöhnliche tief bewegende Adaption von Stephen Kings gleichnamiger Kurzgeschichte. Ein packender, lebensbejahender Film. 
+Geschickt verknüpft der Film die Welt von Stephen Kings Vorlage mit den universellen Fragen des Lebens und findet Magie und Wärme in der zauberhaften Melancholie unseres Daseins. 
+In einer amerikanischen Kleins...</div></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Samstag, 17.01.2026</div><table class=filmtabelle><tr><td class=datumspalte>Samstag<h1>17</h1>Januar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00004929&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: TWIN PEAKS - engl. OmU</h2>
+<img src="/filme/00004929/plakat00004929.jpg" border=0 width=100 align=right alt="Filmplakat TWIN PEAKS - engl. OmU" title="TWIN PEAKS - engl. OmU">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Mit TWIN PEAKS - Der Film war David Lynch im Blockbusterkino angelangt.
+Der Film ist ein Prequel zu der Fernsehserie Twin Peaks (1990?1991). 
+Der Film schildert die letzte Woche im Leben der siebzehnjährigen Laura Palmer. Dabei wird, ähnlich wie zuvor bereits in Blue Velvet, ein Labyrinth aus Sex, Gewalt und Drogen aufgedeckt, das sich hinter der Fassade einer idyllischen Kleinstadt verbirg.
+Be...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13018
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Donnerstag, 22.01.2026</div><table class=filmtabelle><tr><td class=datumspalte>Donnerstag<h1>22</h1>Januar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00004720&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: MULHOLLAND DRIVE - Straße der Finsternis </h2>
+<img src="/filme/00004720/plakat00004720.jpg" border=0 width=100 align=right alt="Filmplakat MULHOLLAND DRIVE - Straße der Finsternis " title="MULHOLLAND DRIVE - Straße der Finsternis ">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Restaurierte Fassung! "Hypnotisch-albtraumhaftes Traum- und Vexierspiel (...) Handwerklich perfekt, ideenreich und inszenatorisch bestechend, zerpflückt der Film lustvoll die Medienmythen der Gegenwart? - Lexikon des intern. Films 
+Nicht nur einer der wichtigsten Filme von Regisseur David Lynch (Twin Peaks, Blue Velvet), sondern auch einer der besten Filme des 21. Jahrhunderts. 
+In der (Doppel-)Ha...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13006
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Freitag, 23.01.2026</div><table class=filmtabelle><tr><td class=datumspalte>Freitag<h1>23</h1>Januar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00000465&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: Blue Valentine engl. OmU </h2>
+<img src="/filme/00000465/plakat00000465.jpg" border=0 width=100 align=right alt="Filmplakat Blue Valentine engl. OmU " title="Blue Valentine engl. OmU ">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>
+ Grandioses, oscarnominiertes Independentdrama, in dem Ryan Gosling und Michelle Williams eine hervorragende Performance geben als Paar, das alle Stationen einer Beziehung durchlebt, das Frischverliebtsein, Routine und aufkommende Probleme und Trennung. 
+In Rückblenden erzählt "Blue Va­len­tine? von der Wahrheit hinter der Love Story und der Zerbrech­lichkeit von Erwartungen. Seine ehr­liche Beob...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13127
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Samstag, 24.01.2026</div><table class=filmtabelle><tr><td class=datumspalte>Samstag<h1>24</h1>Januar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00004994&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: ONE BATTLE AFTER ANOTHER</h2>
+<img src="/filme/00004994/plakat00004994.jpg" border=0 width=100 align=right alt="Filmplakat ONE BATTLE AFTER ANOTHER" title="ONE BATTLE AFTER ANOTHER">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>9 GOLDEN GLOBE-Nominierungen, u.a. als Bester Film, Regie: P.T. Andersom, LeonardoDiCapro, Sean Penn! 
+Nach Filmen wie BOOGIE NIGHTS, MAGNOLIA und LICORIZE PIZZA kommt jetzt Paul Thomas Andersons Verfilmung des Romans von Thomas Pynchons mit LEONARDO DiCAPRIO. 
+DiCaprio spielt Bob Ferguson, der als ehemaliges Mitglied der mysteriösen FRENCH 75 vollkommen durch den Wind bei einer Untergrundorganisa...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13017
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Donnerstag, 29.01.2026</div><table class=filmtabelle><tr><td class=datumspalte>Donnerstag<h1>29</h1>Januar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/01001121&anmerk=OmU-Nachtstudio%20-%20kor.%20OmU"><h2 class=filmtitel>22:45: Oldboy</h2>
+<img src="/filme/01001121/OldBoyPL.jpg" border=0 width=100 align=right alt="Filmplakat Oldboy" title="Oldboy">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio - kor. OmU</div>
+<div class=filminhalt>Großer Preis der Jury bei den Filmfestspielen in Cannes 2004! 
+Einer der einflussreichsten Filme des zeitgenössischen südkoreanischen Kinos. 
+15 Jahre eingesperrt, 5 Tage Zeit für Rache: Ohne erkennbaren Grund wird der Geschäftsmann Oh Dae-su entführt und in einen fensterlosen Raum gesperrt. Sein einziger Kontakt zur Außenwelt ist ein Fernseher, über den er eines Tages aus den Nachrichten erfährt,...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13024
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Freitag, 30.01.2026</div><table class=filmtabelle><tr><td class=datumspalte>Freitag<h1>30</h1>Januar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00004924&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:45: ERASERHEAD - engl. OmU</h2>
+<img src="/filme/00004924/plakat00004924.jpg" border=0 width=100 align=right alt="Filmplakat ERASERHEAD - engl. OmU" title="ERASERHEAD - engl. OmU">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Der Durchbruch von DAVID LYNCH. 
+David Lynchs Frühwerk - einer der Lieblingsfilme von Stanley Kubrick und John Waters!
+Wilde Mischng aus Horrorfilm, Body-Horror, phantastischer, surrealistischer sowie Punk- und Science-Fiction-Film.
+Erzählt wird die Geschichte von Henry Spencers Vaterschaft, die ihn physisch wie psychisch belastet. Als das Baby stirbt, lösen sich Henrys Probleme, aber damit auc...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13026
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Samstag, 31.01.2026</div><table class=filmtabelle><tr><td class=datumspalte>Samstag<h1>31</h1>Januar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005043&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:45: HASS - LA HAINE </h2>
+<img src="/filme/00005043/plakat00005043.jpg" border=0 width=100 align=right alt="Filmplakat HASS - LA HAINE " title="HASS - LA HAINE ">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Zurück im Kino! 
+Ein cinematisch stilvoller Klassiker des französischen Kinos, der mit der Zeit an seiner Schärfe nur zugenommen hat. 
+Proteste gegen die Polizeigewalt in Paris eskalieren. Mittendrinnen - Vinz, Saïd und Hubert - drei Jugendliche aus der sozialschwachen Pariser Vorstadt. Gammeln rum, tun nix und alles gleich - in nur 24 Stunden. Ein cinematisch stilvoller Klassiker des französische...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13025
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Donnerstag, 05.02.2026</div><table class=filmtabelle><tr><td class=datumspalte>Donnerstag<h1>05</h1>Februar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00004925&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: Der Elefantenmensch - engl. OmU</h2>
+<img src="/filme/00004925/plakat00004925.jpg" border=0 width=100 align=right alt="Filmplakat Der Elefantenmensch - engl. OmU" title="Der Elefantenmensch - engl. OmU">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>8 OSCAR-Nominierungen für David Lynchs Reise ins  viktorianische London!
+Joseph Merrick war ein einfacher, schwer geplagter und besonderer Mann, eine tragische Figur, die für die Leinwand wie gemacht scheint. Erzählt wird die Geschichte eines deformierten Briten, dessen körperliche Missbildungen ihm schon bald zu zweifelhaftem Ruhm als Kuriosität und einzigartigem Studienobjekt verhalfen. Kein an...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13104
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Freitag, 06.02.2026</div><table class=filmtabelle><tr><td class=datumspalte>Freitag<h1>06</h1>Februar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005165&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: BUGONIA</h2>
+<img src="/filme/00005165/plakat00005165.jpg" border=0 width=100 align=right alt="Filmplakat BUGONIA" title="BUGONIA">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>3 GOLDEN GLOBE-Nominierungen, u.a. Bester Film, Emma Stone! 
+Der neue Film von Regiemeister GIORGOS LANTHIMOS (POOR THINGS, THE FAVORITTE, THE LOBSTER) wieder mit EMMA STONE (POOR THINGS, LA LA LAND).  
+Zwei Freunde mit einer starken Neigung zu Verschwörungstheorien fassen einen riskanten Plan: Sie entführen die mächtige Geschäftsführerin eines bedeutenden Unternehmens. Angetrieben von ihrer Überz...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13105
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Samstag, 07.02.2026</div><table class=filmtabelle><tr><td class=datumspalte>Samstag<h1>07</h1>Februar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005159&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: DIE, MY LOVE</h2>
+<img src="/filme/00005159/plakat00005159.jpg" border=0 width=100 align=right alt="Filmplakat DIE, MY LOVE" title="DIE, MY LOVE">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Jennifer Lawrence + Robert Pattinson als junges Paar neu auf dem Land... - "Hit von Cannes""-Der Spiegel - "Jennifer Lawrence brilliert (...) strahlt schlichtweg eine überwältigende Kraft aus"-The Guardian 
+ 
+Das verliebte junge Paar Grace (Jennifer Lawrence) und Jackson (Robert Pattinson) zieht von New York in ein geerbtes Haus auf dem Land. In der Abgeschiedenheit sucht Grace nach ihrer Identitä...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13106
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Donnerstag, 12.02.2026</div><table class=filmtabelle><tr><td class=datumspalte>Donnerstag<h1>12</h1>Februar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005174&anmerk=%20OmU-Nachtstudio"><h2 class=filmtitel>22:30: SENTIMENTAL VALUE </h2>
+<img src="/filme/00005174/SentimentalValueplDtNeu.jpg" border=0 width=100 align=right alt="Filmplakat SENTIMENTAL VALUE " title="SENTIMENTAL VALUE ">
+</a>
+<div class=filmanmerkung> OmU-Nachtstudio</div>
+<div class=filminhalt>8 GOLDEN GLOBE-Nominierungen, u.a. Bester Film, Beste Regie, Beste Hauptdarstellerin! 
+Nominiert für 5 Europäische Filmpreise (u.a. Bester Film, Beste Regie, Beste darstellerin, Bester Darsteller). Norw. OSCAR-Beitrag! Publikumspreis Filmfest München! 
+Ein neuer sensibler Film voller Emotionen von JOACHIM TRIER (DER schlimmste Mensch der Welt), wieder mit RENATE REINSVE, die mit dem Großen Preis d...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13107
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Freitag, 13.02.2026</div><table class=filmtabelle><tr><td class=datumspalte>Freitag<h1>13</h1>Februar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00004924&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:45: ERASERHEAD - engl. OmU</h2>
+<img src="/filme/00004924/plakat00004924.jpg" border=0 width=100 align=right alt="Filmplakat ERASERHEAD - engl. OmU" title="ERASERHEAD - engl. OmU">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Der Durchbruch von DAVID LYNCH. 
+David Lynchs Frühwerk - einer der Lieblingsfilme von Stanley Kubrick und John Waters!
+Wilde Mischng aus Horrorfilm, Body-Horror, phantastischer, surrealistischer sowie Punk- und Science-Fiction-Film.
+Erzählt wird die Geschichte von Henry Spencers Vaterschaft, die ihn physisch wie psychisch belastet. Als das Baby stirbt, lösen sich Henrys Probleme, aber damit auc...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13109
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Samstag, 14.02.2026</div><table class=filmtabelle><tr><td class=datumspalte>Samstag<h1>14</h1>Februar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/01000749&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: Der weisse Hai</h2>
+<img src="/filme/01000749/plakat01000749.jpg" border=0 width=100 align=right alt="Filmplakat Der weisse Hai" title="Der weisse Hai">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Steven Spiebergs Hai-Blockbuster  von 1975 mit Roy Scheider, Robert Shaw, Richard Dreyfuss, Lorraine Gary ist der Meilenstein des Kinos der 70er Jahre! 
+Spielberg vermischt Humor und Wohlbekanntes mit Horror und ungeahnten Schrecken. 
+An den Stränden eines kleinen Badeortes an der amerikanischen Ostküste taucht mitten in der Hauptsaison ein riesiger weißer Hai auf und verbreitet Angst und Schrecke...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13110
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Donnerstag, 19.02.2026</div><table class=filmtabelle><tr><td class=datumspalte>Donnerstag<h1>19</h1>Februar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00004927&anmerk=OmU-Nachtstudio%20%96"><h2 class=filmtitel>22:30: LOST HIGHWAY - engl. OmU</h2>
+<img src="/filme/00004927/plakat00004927.jpg" border=0 width=100 align=right alt="Filmplakat LOST HIGHWAY - engl. OmU" title="LOST HIGHWAY - engl. OmU">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio –</div>
+<div class=filminhalt>Von David Lynch! "Verstörende, äußerst komplexe Reise ins Unheimliche, die mit den Mitteln der Verrätselung und des Horrorfilms den Zuschauer in Bann schlägt. Ein filmisches Meisterwerk..."
+
+Die Ehe des Jazz-Saxophonisten Fred Madison ist am Abgrund. Als er nach einer Party festgenommen wird und des Mordes seiner Frau Renee beschuldigt wird, landet er in der Todeszelle. Geplagt von starken Kopfs...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13111
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Freitag, 20.02.2026</div><table class=filmtabelle><tr><td class=datumspalte>Freitag<h1>20</h1>Februar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/01001104&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: FARGO</h2>
+<img src="/filme/01001104/FargoPL.jpg" border=0 width=100 align=right alt="Filmplakat FARGO" title="FARGO">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Vor THREE BILLBOARDS OUTSIDE EBBING, MISSOURI gewann FRANCES MC DERMAND bereits einen OSCAR als Beste Hauptdarstellerin!!! 
+2 OSCARS, u.a. für FRANCES MC DERMAND als Beste Hauptdarstellerin! 
+Regiepreis bei den Filmfestspelen in Cannes! 
+Ein echter Coen — witzig, dramatisch, spannend, gut und jetzt wieder auf der Kinoleinwand zu erleben! 
+Es könnte der Plan zum perfekten Verbrechen sein: Der abgeb...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13112
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Samstag, 21.02.2026</div><table class=filmtabelle><tr><td class=datumspalte>Samstag<h1>21</h1>Februar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005043&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: HASS - LA HAINE </h2>
+<img src="/filme/00005043/plakat00005043.jpg" border=0 width=100 align=right alt="Filmplakat HASS - LA HAINE " title="HASS - LA HAINE ">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Zurück im Kino! 
+Ein cinematisch stilvoller Klassiker des französischen Kinos, der mit der Zeit an seiner Schärfe nur zugenommen hat. 
+Proteste gegen die Polizeigewalt in Paris eskalieren. Mittendrinnen - Vinz, Saïd und Hubert - drei Jugendliche aus der sozialschwachen Pariser Vorstadt. Gammeln rum, tun nix und alles gleich - in nur 24 Stunden. Ein cinematisch stilvoller Klassiker des französische...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13113
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Donnerstag, 26.02.2026</div><table class=filmtabelle><tr><td class=datumspalte>Donnerstag<h1>26</h1>Februar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00004720&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: MULHOLLAND DRIVE - Straße der Finsternis </h2>
+<img src="/filme/00004720/plakat00004720.jpg" border=0 width=100 align=right alt="Filmplakat MULHOLLAND DRIVE - Straße der Finsternis " title="MULHOLLAND DRIVE - Straße der Finsternis ">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Restaurierte Fassung! "Hypnotisch-albtraumhaftes Traum- und Vexierspiel (...) Handwerklich perfekt, ideenreich und inszenatorisch bestechend, zerpflückt der Film lustvoll die Medienmythen der Gegenwart? - Lexikon des intern. Films 
+Nicht nur einer der wichtigsten Filme von Regisseur David Lynch (Twin Peaks, Blue Velvet), sondern auch einer der besten Filme des 21. Jahrhunderts. 
+In der (Doppel-)Ha...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13114
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Freitag, 27.02.2026</div><table class=filmtabelle><tr><td class=datumspalte>Freitag<h1>27</h1>Februar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005187&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: Therapie für Wikinger</h2>
+<img src="/filme/00005187/TherapieFurWikingerPL.jpg" border=0 width=100 align=right alt="Filmplakat Therapie für Wikinger" title="Therapie für Wikinger">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>MADS MIKKELSEN im neuen Film von Anders Thomas Jensen (Adams Äpfel, Helden der Wahrscheinlichkeit)! Eine abgründige Krimi-Komödie über konfuse Identitäten und zwei Brüder, die sich mögen. 
+Hier gibt es Pointen-Material im Sekundentakt, hinreißend unberechenbar und bösartig witzig! 
+Nach 15 Jahren wegen Bankraub wird Anker aus dem Gefängnis entlassen. Die Beute hat damals sein Bruder Manfred vergra...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13117
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Samstag, 28.02.2026</div><table class=filmtabelle><tr><td class=datumspalte>Samstag<h1>28</h1>Februar</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005202&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: HAMNET</h2>
+<img src="/filme/00005202/plakat00005202.jpg" border=0 width=100 align=right alt="Filmplakat HAMNET" title="HAMNET">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>6 GOLDEN GLOBE-Nominierungen, u.a. Bester Film, Beste Regie! 
+Nach NOMADLAND der neue mitreißende Film von Chloé Zhao über die Entstehung von Shakespeares HAMLET - "...wird ein Siegeszug ohne gleichen noch erleben." (Die Zeit) 
+Die mitreißende Geschichte um Liebe und Verlust, die Shakespeare zu seinem zeitlosen Meisterwerk HAMLET inspirierte. Ein Film von Regisseurin Chloé Zhao (NOMADLAND), basier...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13116
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Donnerstag, 05.03.2026</div><table class=filmtabelle><tr><td class=datumspalte>Donnerstag<h1>05</h1>M&auml;rz</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005210&anmerk=%20OmU-Nachtstudio%20%96"><h2 class=filmtitel>22:30: SONG SUNG BLUE</h2>
+<img src="/filme/00005210/SongSungBluePL.jpg" border=0 width=100 align=right alt="Filmplakat SONG SUNG BLUE" title="SONG SUNG BLUE">
+</a>
+<div class=filmanmerkung> OmU-Nachtstudio –</div>
+<div class=filminhalt>GOLDE GLOBE-Nominierung für KATE HUDSON! 
+Bewegendes Kino mit Hugh Jackman + Kate Hudson als NEIL DIAMOND-Tribute-Duo!  
+Inspiriert von wahren Begebenheiten: In SONG SUNG BLUE wagen zwei Musiker in ihrer Lebensmitte (Hugh Jackman und Kate Hudson), die noch immer vom großen Durchbruch träumen, einen mutigen Neuanfang. Sie gründen eine Neil-Diamond-Tribute-Band ? und beweisen, dass es nie zu spät is...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13197
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Freitag, 06.03.2026</div><table class=filmtabelle><tr><td class=datumspalte>Freitag<h1>06</h1>M&auml;rz</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005159&anmerk=%20OmU-Nachtstudio%20%96"><h2 class=filmtitel>22:30: DIE, MY LOVE</h2>
+<img src="/filme/00005159/plakat00005159.jpg" border=0 width=100 align=right alt="Filmplakat DIE, MY LOVE" title="DIE, MY LOVE">
+</a>
+<div class=filmanmerkung> OmU-Nachtstudio –</div>
+<div class=filminhalt>Jennifer Lawrence + Robert Pattinson als junges Paar neu auf dem Land... - "Hit von Cannes""-Der Spiegel - "Jennifer Lawrence brilliert (...) strahlt schlichtweg eine überwältigende Kraft aus"-The Guardian 
+ 
+Das verliebte junge Paar Grace (Jennifer Lawrence) und Jackson (Robert Pattinson) zieht von New York in ein geerbtes Haus auf dem Land. In der Abgeschiedenheit sucht Grace nach ihrer Identitä...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13198
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Samstag, 07.03.2026</div><table class=filmtabelle><tr><td class=datumspalte>Samstag<h1>07</h1>M&auml;rz</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005043&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:45: HASS - LA HAINE </h2>
+<img src="/filme/00005043/plakat00005043.jpg" border=0 width=100 align=right alt="Filmplakat HASS - LA HAINE " title="HASS - LA HAINE ">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Zurück im Kino! 
+Ein cinematisch stilvoller Klassiker des französischen Kinos, der mit der Zeit an seiner Schärfe nur zugenommen hat. 
+Proteste gegen die Polizeigewalt in Paris eskalieren. Mittendrinnen - Vinz, Saïd und Hubert - drei Jugendliche aus der sozialschwachen Pariser Vorstadt. Gammeln rum, tun nix und alles gleich - in nur 24 Stunden. Ein cinematisch stilvoller Klassiker des französische...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13199
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Donnerstag, 12.03.2026</div><table class=filmtabelle><tr><td class=datumspalte>Donnerstag<h1>12</h1>M&auml;rz</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005151&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: Der Hochstapler</h2>
+<img src="/filme/00005151/plakat00005151.jpg" border=0 width=100 align=right alt="Filmplakat Der Hochstapler" title="Der Hochstapler">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Kriminalfilm von Derek Cianfrance (Blue Valentine, The Place Beyond the Pines) nach der wahren Geschichte des exzentrischen Serienräuber Jeffrey Manchester, der mehr als 60 Fillialen einer Fast-Food-Kette ausraubte. 
+Der ehemalige Army Ranger beginnt, Löcher in die ihre von Mc Donalds-Restaurants zu schneiden, wodurch er den Spitznamen ROOFMAN erhält. 
+Nachdem er aus dem Gefängnis entkommt, lebt e...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13200
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Freitag, 13.03.2026</div><table class=filmtabelle><tr><td class=datumspalte>Freitag<h1>13</h1>M&auml;rz</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005202&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:30: HAMNET</h2>
+<img src="/filme/00005202/plakat00005202.jpg" border=0 width=100 align=right alt="Filmplakat HAMNET" title="HAMNET">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>6 GOLDEN GLOBE-Nominierungen, u.a. Bester Film, Beste Regie! 
+Nach NOMADLAND der neue mitreißende Film von Chloé Zhao über die Entstehung von Shakespeares HAMLET - "...wird ein Siegeszug ohne gleichen noch erleben." (Die Zeit) 
+Die mitreißende Geschichte um Liebe und Verlust, die Shakespeare zu seinem zeitlosen Meisterwerk HAMLET inspirierte. Ein Film von Regisseurin Chloé Zhao (NOMADLAND), basier...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13201
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Samstag, 14.03.2026</div><table class=filmtabelle><tr><td class=datumspalte>Samstag<h1>14</h1>M&auml;rz</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005165&anmerk=%20OmU-Nachtstudio%20%96"><h2 class=filmtitel>22:45: BUGONIA</h2>
+<img src="/filme/00005165/plakat00005165.jpg" border=0 width=100 align=right alt="Filmplakat BUGONIA" title="BUGONIA">
+</a>
+<div class=filmanmerkung> OmU-Nachtstudio –</div>
+<div class=filminhalt>3 GOLDEN GLOBE-Nominierungen, u.a. Bester Film, Emma Stone! 
+Der neue Film von Regiemeister GIORGOS LANTHIMOS (POOR THINGS, THE FAVORITTE, THE LOBSTER) wieder mit EMMA STONE (POOR THINGS, LA LA LAND).  
+Zwei Freunde mit einer starken Neigung zu Verschwörungstheorien fassen einen riskanten Plan: Sie entführen die mächtige Geschäftsführerin eines bedeutenden Unternehmens. Angetrieben von ihrer Überz...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13202
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Donnerstag, 19.03.2026</div><table class=filmtabelle><tr><td class=datumspalte>Donnerstag<h1>19</h1>M&auml;rz</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00004994&anmerk=%20OmU-Nachtstudio%20%96"><h2 class=filmtitel>22:30: ONE BATTLE AFTER ANOTHER</h2>
+<img src="/filme/00004994/plakat00004994.jpg" border=0 width=100 align=right alt="Filmplakat ONE BATTLE AFTER ANOTHER" title="ONE BATTLE AFTER ANOTHER">
+</a>
+<div class=filmanmerkung> OmU-Nachtstudio –</div>
+<div class=filminhalt>9 GOLDEN GLOBE-Nominierungen, u.a. als Bester Film, Regie: P.T. Andersom, LeonardoDiCapro, Sean Penn! 
+Nach Filmen wie BOOGIE NIGHTS, MAGNOLIA und LICORIZE PIZZA kommt jetzt Paul Thomas Andersons Verfilmung des Romans von Thomas Pynchons mit LEONARDO DiCAPRIO. 
+DiCaprio spielt Bob Ferguson, der als ehemaliges Mitglied der mysteriösen FRENCH 75 vollkommen durch den Wind bei einer Untergrundorganisa...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13210
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Freitag, 20.03.2026</div><table class=filmtabelle><tr><td class=datumspalte>Freitag<h1>20</h1>M&auml;rz</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/01001121&anmerk=OmU-Nachtstudio%20-%20kor.%20OmU"><h2 class=filmtitel>22:45: Oldboy</h2>
+<img src="/filme/01001121/OldBoyPL.jpg" border=0 width=100 align=right alt="Filmplakat Oldboy" title="Oldboy">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio - kor. OmU</div>
+<div class=filminhalt>Großer Preis der Jury bei den Filmfestspielen in Cannes 2004! 
+Einer der einflussreichsten Filme des zeitgenössischen südkoreanischen Kinos. 
+15 Jahre eingesperrt, 5 Tage Zeit für Rache: Ohne erkennbaren Grund wird der Geschäftsmann Oh Dae-su entführt und in einen fensterlosen Raum gesperrt. Sein einziger Kontakt zur Außenwelt ist ein Fernseher, über den er eines Tages aus den Nachrichten erfährt,...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13211
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Donnerstag, 26.03.2026</div><table class=filmtabelle><tr><td class=datumspalte>Donnerstag<h1>26</h1>M&auml;rz</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/01001104&anmerk=OmU-Nachtstudio"><h2 class=filmtitel>22:45: FARGO</h2>
+<img src="/filme/01001104/FargoPL.jpg" border=0 width=100 align=right alt="Filmplakat FARGO" title="FARGO">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio</div>
+<div class=filminhalt>Vor THREE BILLBOARDS OUTSIDE EBBING, MISSOURI gewann FRANCES MC DERMAND bereits einen OSCAR als Beste Hauptdarstellerin!!! 
+2 OSCARS, u.a. für FRANCES MC DERMAND als Beste Hauptdarstellerin! 
+Regiepreis bei den Filmfestspelen in Cannes! 
+Ein echter Coen — witzig, dramatisch, spannend, gut und jetzt wieder auf der Kinoleinwand zu erleben! 
+Es könnte der Plan zum perfekten Verbrechen sein: Der abgeb...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13212
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Freitag, 27.03.2026</div><table class=filmtabelle><tr><td class=datumspalte>Freitag<h1>27</h1>M&auml;rz</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00005227&anmerk=%20OmU-Nachtstudio%20%96"><h2 class=filmtitel>22:30: Ein einfacher Unfall</h2>
+<img src="/filme/00005227/plakat00005227.jpg" border=0 width=100 align=right alt="Filmplakat Ein einfacher Unfall" title="Ein einfacher Unfall">
+</a>
+<div class=filmanmerkung> OmU-Nachtstudio –</div>
+<div class=filminhalt>GOLDENE PALME-Filmfestspiele Cannes! 4 GOLDEN GLOBE-Nominierungen, u.a. Bester Film, Beste Regie!
+Ausgehend von einem kleinen Moment der Unaufmerksamkeit schafft Panahi ein kraftvolles und intensives moralisches Drama, das sich mit verdrängten Traumata, staatlicher Gewalt, Gerechtigkeit und Straflosigkeit auseinandersetzt.
+Vahid, ein aserbaidschanischer Automechaniker, wurde einst vom iranischen...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13213
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table><br><div class=datumzeile>Samstag, 28.03.2026</div><table class=filmtabelle><tr><td class=datumspalte>Samstag<h1>28</h1>M&auml;rz</td><td><table class=tagestabelle>
+<tr><td><a href="/?v=&film=filme/00004927&anmerk=OmU-Nachtstudio%20%96"><h2 class=filmtitel>22:30: LOST HIGHWAY - engl. OmU</h2>
+<img src="/filme/00004927/plakat00004927.jpg" border=0 width=100 align=right alt="Filmplakat LOST HIGHWAY - engl. OmU" title="LOST HIGHWAY - engl. OmU">
+</a>
+<div class=filmanmerkung>OmU-Nachtstudio –</div>
+<div class=filminhalt>Von David Lynch! "Verstörende, äußerst komplexe Reise ins Unheimliche, die mit den Mitteln der Verrätselung und des Horrorfilms den Zuschauer in Bann schlägt. Ein filmisches Meisterwerk..."
+
+Die Ehe des Jazz-Saxophonisten Fred Madison ist am Abgrund. Als er nach einer Party festgenommen wird und des Mordes seiner Frau Renee beschuldigt wird, landet er in der Todeszelle. Geplagt von starken Kopfs...</div><br /><form action=https://kinotickets.express/apollo_hannover/booking/13214
+ target=tickets><input type=submit value="Tickets kaufen"></form></div>
+</td></tr>
+</table></td></tr></table></div></div></body></html>

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -21,6 +21,7 @@ from boringhannover.sources.cinema.astor import AstorSource as AstorMovieScraper
 from boringhannover.sources.concerts.zag_arena import (
     ZAGArenaSource as ConcertVenueScraper,
 )
+from boringhannover.sources.cinema.apollokino import ApollokinoSource as ApollokinoScraper
 
 
 # =============================================================================
@@ -233,6 +234,54 @@ class TestConcertVenueScraper:
         """Test scraper has max events limit configured."""
         scraper = ConcertVenueScraper()
         assert scraper.max_events == 15
+
+
+class TestApollokinoScraper:
+    """Tests for the Apollokino scraper."""
+
+    def test_scraper_source_name(self) -> None:
+        scraper = ApollokinoScraper()
+        assert scraper.source_name == "Apollokino Hannover"
+
+    @patch("boringhannover.sources.base.httpx.Client")
+    def test_fetch_returns_list(self, mock_client: Mock) -> None:
+        """Fetch should return a list when given real HTML."""
+        mock_response = Mock()
+        # Use the saved HTML snapshot for deterministic parsing
+        with open("tests/fixtures/apollokino_omu.html", "r", encoding="utf-8") as fh:
+            html = fh.read()
+
+        mock_response.text = html
+        mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+
+        scraper = ApollokinoScraper()
+        result = scraper.fetch()
+
+        assert isinstance(result, list)
+
+    @patch("boringhannover.sources.base.httpx.Client")
+    def test_fetch_parses_omu_entries(self, mock_client: Mock) -> None:
+        """Ensure OmU entries are parsed and include expected metadata."""
+        mock_response = Mock()
+        with open("tests/fixtures/apollokino_omu.html", "r", encoding="utf-8") as fh:
+            html = fh.read()
+
+        mock_response.text = html
+        mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+
+        scraper = ApollokinoScraper()
+        result = scraper.fetch()
+
+        # Should parse at least one OmU movie and include metadata keys
+        assert len(result) > 0
+        ev = result[0]
+        assert ev.category == "movie"
+        assert ev.title == "THE MASTERMIND"
+        assert ev.date.strftime("%H:%M") == "22:30"
+        assert ev.metadata.get("poster_url") == "https://www.apollokino.de/filme/00005138/plakat00005138.jpg"
+        assert ev.url == "https://www.apollokino.de/?v=&film=filme/00005138&anmerk=OmU-Nachtstudio"
+        # TODO: check language when field is available
+        assert ev.metadata.get("original_version") is True
 
 
 class TestFetchAllEvents:


### PR DESCRIPTION
Hey Sia,
I added a source for Apollokino Linden, that scrapes the HTML of https://www.apollokino.de/?v=&mp=OmU-Nachtstudio (Original mit Untertitel), please review :) 

Based on the overview list and `MOVIES_LOOKAHEAD_DAYS` it also scrapes detail pages to get more metadata. It sticks to the existing metadata properties and value formatting present for Astor. 

Since it's not structured JSON data, it relies on string patterns found on the live page. I attach an example file of different filmdaten (metadata) that shows they don't simply have one pattern they stick to. So it needs to be observed, possibly tweaked, extracted by a LLM or replaced by a structured source.

[filmdaten.html](https://github.com/user-attachments/files/24395167/filmdaten.html)
